### PR TITLE
Fix GitHub context provider param

### DIFF
--- a/adapters/continue_dev.py
+++ b/adapters/continue_dev.py
@@ -75,7 +75,8 @@ class ContinueAdapter:
                             "name": "github",
                             "params": {
                                 "token": service_params["api_token"],
-                                "repo": service_params.get("default_repo", "")
+                                "repo": service_params.get("default_repo")
+                                        or service_params.get("default_org", "")
                             }
                         })
                 


### PR DESCRIPTION
## Summary
- fix GitHub repo lookup in Continue adapter

## Testing
- `python3 -m py_compile ai-dotfiles adapters/*.py`

------
https://chatgpt.com/codex/tasks/task_e_688b6dd826bc83269da0a5cc48a7b2dc